### PR TITLE
Use Cryptographically Secure PRNG instead of Rng

### DIFF
--- a/oee.rs
+++ b/oee.rs
@@ -11,10 +11,13 @@ fn main() {
         return
     }
 
-    let mut rng = rand::thread_rng();
+    let mut csprng = match rand::OsRng::new() {
+        Ok(g) => g,
+        Err(e) => panic!("Could not find a cryptographically-secure PRNG on the system. Details: {}", e)
+    };
 
     let mut cyphertext = [0u8; CYPHERBYTES];
-    rng.fill_bytes(&mut cyphertext);
+    csprng.fill_bytes(&mut cyphertext);
     for x in &cyphertext { print!("{:02x}", *x); }
     println!("")
 }


### PR DESCRIPTION
I was absolutely shocked when I saw OEE was using an **insecure** pseudo-random number generator!

But don't take my word for it, as stated in [the Rust documentation](https://doc.rust-lang.org/rand/rand/index.html#cryptographic-security):

> An application that requires an entropy source for cryptographic purposes
> must use OsRng, which reads randomness from the source that the operating
> system provides (e.g. /dev/urandom on Unixes or CryptGenRandom() on Windows).
> The other random number generators provided by this module are not suitable
> for such purposes.

I have attached changes (tested on Ubuntu 14.04) that rectify this security hole.